### PR TITLE
Added some control code to KeyEvent translations.

### DIFF
--- a/src/event/sys/unix/parse.rs
+++ b/src/event/sys/unix/parse.rs
@@ -80,6 +80,31 @@ pub(crate) fn parse_event(buffer: &[u8], input_available: bool) -> Result<Option
         b'\x7F' => Ok(Some(InternalEvent::Event(Event::Key(
             KeyCode::Backspace.into(),
         )))),
+        // Backspace control code
+        b'\x08' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Backspace,
+            KeyModifiers::NONE,
+        ))))),
+        // Tab control code
+        b'\x09' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Tab,
+            KeyModifiers::NONE,
+        ))))),
+        // Linefeed control code
+        b'\x0a' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        ))))),
+        // Return control code
+        b'\x0d' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Enter,
+            KeyModifiers::NONE,
+        ))))),
+        // 'Delete word' control code
+        b'\x17' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
+            KeyCode::Backspace,
+            KeyModifiers::CONTROL,
+        ))))),
         c @ b'\x01'..=b'\x1A' => Ok(Some(InternalEvent::Event(Event::Key(KeyEvent::new(
             KeyCode::Char((c as u8 - 0x1 + b'a') as char),
             KeyModifiers::CONTROL,


### PR DESCRIPTION
This code is throwing some errors I'm unable to understand. Blaming about b'\x09' and b'\x0d'.